### PR TITLE
Updated to Use New Protocol Layer

### DIFF
--- a/eng/code-quality-reports/src/main/resources/spotbugs/spotbugs-exclude.xml
+++ b/eng/code-quality-reports/src/main/resources/spotbugs/spotbugs-exclude.xml
@@ -65,6 +65,8 @@
     <Or>
       <Class name="com.microsoft.azure.keyvault.authentication.KeyVaultCredentials"/>
       <Class name="com.azure.storage.blob.implementation.AzureBlobStorageBuilder"/>
+      <Class name="com.azure.storage.file.implementation.AzureFileStorageBuilder"/>
+      <Class name="com.azure.storage.file.implementation.AzureQueueStorageBuilder"/>
     </Or>
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
   </Match>

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/AppendBlobAsyncClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/AppendBlobAsyncClient.java
@@ -94,8 +94,8 @@ public final class AppendBlobAsyncClient extends BlobAsyncClient {
         accessConditions = (accessConditions == null) ? new BlobAccessConditions() : accessConditions;
 
         return postProcessResponse(this.azureBlobStorage.appendBlobs().createWithRestResponseAsync(null,
-            null, 0, null, metadata, null, null,
-            null, null, headers, accessConditions.leaseAccessConditions(),
+            null, 0, null, metadata, null, null, null,
+            null, null, headers, accessConditions.leaseAccessConditions(), null,
             accessConditions.modifiedAccessConditions(), Context.NONE))
             .map(rb -> new SimpleResponse<>(rb, new AppendBlobItem(rb.deserializedHeaders())));
     }
@@ -144,10 +144,10 @@ public final class AppendBlobAsyncClient extends BlobAsyncClient {
             : appendBlobAccessConditions;
 
         return postProcessResponse(this.azureBlobStorage.appendBlobs().appendBlockWithRestResponseAsync(
-            null, null, data, length, null, null,
+            null, null, data, length, null, null, null,
             null, null, null, null,
             appendBlobAccessConditions.leaseAccessConditions(),
-            appendBlobAccessConditions.appendPositionAccessConditions(),
+            appendBlobAccessConditions.appendPositionAccessConditions(), null,
             appendBlobAccessConditions.modifiedAccessConditions(), Context.NONE))
             .map(rb -> new SimpleResponse<>(rb, new AppendBlobItem(rb.deserializedHeaders())));
     }
@@ -201,7 +201,7 @@ public final class AppendBlobAsyncClient extends BlobAsyncClient {
 
         return postProcessResponse(
             this.azureBlobStorage.appendBlobs().appendBlockFromUrlWithRestResponseAsync(null, null,
-                sourceURL, 0, sourceRange.toString(), sourceContentMD5, null, null,
+                sourceURL, 0, sourceRange.toString(), sourceContentMD5, null, null, null, null,
                 destAccessConditions.leaseAccessConditions(),
                 destAccessConditions.appendPositionAccessConditions(),
                 destAccessConditions.modifiedAccessConditions(), sourceAccessConditions, Context.NONE))

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/BlobAsyncClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/BlobAsyncClient.java
@@ -13,6 +13,7 @@ import com.azure.core.util.Context;
 import com.azure.storage.blob.implementation.AzureBlobStorageBuilder;
 import com.azure.storage.blob.implementation.AzureBlobStorageImpl;
 import com.azure.storage.blob.models.AccessTier;
+import com.azure.storage.blob.models.AccessTierRequired;
 import com.azure.storage.blob.models.BlobAccessConditions;
 import com.azure.storage.blob.models.BlobHTTPHeaders;
 import com.azure.storage.blob.models.BlobRange;
@@ -245,7 +246,7 @@ public class BlobAsyncClient {
             .sourceIfNoneMatch(sourceModifiedAccessConditions.ifNoneMatch());
 
         return postProcessResponse(this.azureBlobStorage.blobs().startCopyFromURLWithRestResponseAsync(
-            null, null, sourceURL, null, metadata, null, sourceConditions,
+            null, null, sourceURL, null, metadata, null, null, null, null, sourceConditions,
             destAccessConditions.modifiedAccessConditions(), destAccessConditions.leaseAccessConditions(), Context.NONE))
             .map(rb -> new SimpleResponse<>(rb, rb.deserializedHeaders().copyId()));
     }
@@ -340,7 +341,7 @@ public class BlobAsyncClient {
             .sourceIfNoneMatch(sourceModifiedAccessConditions.ifNoneMatch());
 
         return postProcessResponse(this.azureBlobStorage.blobs().copyFromURLWithRestResponseAsync(
-            null, null, copySource, null, metadata, null, sourceConditions,
+            null, null, copySource, null, metadata, null, null, null, sourceConditions,
             destAccessConditions.modifiedAccessConditions(), destAccessConditions.leaseAccessConditions(), Context.NONE))
             .map(rb -> new SimpleResponse<>(rb, rb.deserializedHeaders().copyId()));
     }
@@ -413,7 +414,7 @@ public class BlobAsyncClient {
         // TODO: range is BlobRange but expected as String
         // TODO: figure out correct response
         return postProcessResponse(this.azureBlobStorage.blobs().downloadWithRestResponseAsync(
-            null, null, snapshot, null, null, range.toHeaderValue(), getMD5,
+            null, null, snapshot, null, null, range.toHeaderValue(), getMD5, null,
             null, null, null, null,
             accessConditions.leaseAccessConditions(), accessConditions.modifiedAccessConditions(), Context.NONE))
             // Convert the autorest response to a DownloadAsyncResponse, which enable reliable download.
@@ -691,7 +692,7 @@ public class BlobAsyncClient {
 
         return postProcessResponse(this.azureBlobStorage.blobs().setMetadataWithRestResponseAsync(
             null, null, null, metadata, null, null,
-            null, null, accessConditions.leaseAccessConditions(),
+            null, null, accessConditions.leaseAccessConditions(), null,
             accessConditions.modifiedAccessConditions(), Context.NONE))
             .map(VoidResponse::new);
     }
@@ -734,7 +735,7 @@ public class BlobAsyncClient {
 
         return postProcessResponse(this.azureBlobStorage.blobs().createSnapshotWithRestResponseAsync(
             null, null, null, metadata, null, null,
-            null, null, accessConditions.modifiedAccessConditions(),
+            null, null, null, accessConditions.modifiedAccessConditions(),
             accessConditions.leaseAccessConditions(), Context.NONE))
             .map(rb -> new SimpleResponse<>(rb, this.getSnapshotClient(rb.deserializedHeaders().snapshot())));
     }
@@ -779,9 +780,10 @@ public class BlobAsyncClient {
      */
     public Mono<VoidResponse> setTier(AccessTier tier, LeaseAccessConditions leaseAccessConditions) {
         Utility.assertNotNull("tier", tier);
+        AccessTierRequired accessTierRequired = AccessTierRequired.fromString(tier.toString());
 
         return postProcessResponse(this.azureBlobStorage.blobs().setTierWithRestResponseAsync(
-            null, null, tier, null, null, leaseAccessConditions, Context.NONE))
+            null, null, accessTierRequired, null, null, null, leaseAccessConditions, Context.NONE))
             .map(VoidResponse::new);
     }
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/BlockBlobAsyncClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/BlockBlobAsyncClient.java
@@ -152,8 +152,8 @@ public final class BlockBlobAsyncClient extends BlobAsyncClient {
         accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
 
         return postProcessResponse(this.azureBlobStorage.blockBlobs().uploadWithRestResponseAsync(null,
-            null, data, length, null, metadata, null, null,
-            null, null, headers, accessConditions.leaseAccessConditions(),
+            null, data, length, null, metadata, null, null, null,
+            null, null, null, headers, accessConditions.leaseAccessConditions(), null,
             accessConditions.modifiedAccessConditions(), Context.NONE))
             .map(rb -> new SimpleResponse<>(rb, new BlockBlobItem(rb.deserializedHeaders())));
     }
@@ -297,8 +297,8 @@ public final class BlockBlobAsyncClient extends BlobAsyncClient {
     public Mono<VoidResponse> stageBlock(String base64BlockID, Flux<ByteBuf> data, long length,
                  LeaseAccessConditions leaseAccessConditions) {
         return postProcessResponse(this.azureBlobStorage.blockBlobs().stageBlockWithRestResponseAsync(null,
-            null, base64BlockID, length, data, null, null, null,
-            null, null, null, leaseAccessConditions, Context.NONE))
+            null, base64BlockID, length, data, null, null, null, null,
+            null, null, null, leaseAccessConditions, null, Context.NONE))
             .map(VoidResponse::new);
     }
 
@@ -359,9 +359,9 @@ public final class BlockBlobAsyncClient extends BlobAsyncClient {
 
         return postProcessResponse(
             this.azureBlobStorage.blockBlobs().stageBlockFromURLWithRestResponseAsync(null, null,
-                base64BlockID, 0, sourceURL, sourceRange.toHeaderValue(), sourceContentMD5, null,
+                base64BlockID, 0, sourceURL, sourceRange.toHeaderValue(), sourceContentMD5, null, null,
                 null, null, null, null,
-                leaseAccessConditions, sourceModifiedAccessConditions, Context.NONE))
+                leaseAccessConditions, null, sourceModifiedAccessConditions, Context.NONE))
             .map(VoidResponse::new);
     }
 
@@ -456,9 +456,9 @@ public final class BlockBlobAsyncClient extends BlobAsyncClient {
         accessConditions = accessConditions == null ? new BlobAccessConditions() : accessConditions;
 
         return postProcessResponse(this.azureBlobStorage.blockBlobs().commitBlockListWithRestResponseAsync(
-            null, null, new BlockLookupList().latest(base64BlockIDs), null, metadata,
-            null, null, null, null, headers,
-            accessConditions.leaseAccessConditions(), accessConditions.modifiedAccessConditions(), Context.NONE))
+            null, null, new BlockLookupList().latest(base64BlockIDs), null, null, null, metadata, null,
+            null, null, null, null, null, headers,
+            accessConditions.leaseAccessConditions(), null, accessConditions.modifiedAccessConditions(), Context.NONE))
             .map(rb -> new SimpleResponse<>(rb, new BlockBlobItem(rb.deserializedHeaders())));
     }
 }

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/ContainerAsyncClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/ContainerAsyncClient.java
@@ -278,7 +278,7 @@ public final class ContainerAsyncClient {
         metadata = metadata == null ? new Metadata() : metadata;
 
         return postProcessResponse(this.azureBlobStorage.containers().createWithRestResponseAsync(
-            null, null, metadata, accessType, null, Context.NONE))
+            null, null, metadata, accessType, null, null, null, Context.NONE))
             .map(VoidResponse::new);
     }
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/PageBlobAsyncClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/PageBlobAsyncClient.java
@@ -127,8 +127,8 @@ public final class PageBlobAsyncClient extends BlobAsyncClient {
         metadata = metadata == null ? new Metadata() : metadata;
 
         return postProcessResponse(this.azureBlobStorage.pageBlobs().createWithRestResponseAsync(null,
-            null, 0, size, null, metadata, null, null,
-            null, sequenceNumber, null, headers, accessConditions.leaseAccessConditions(),
+            null, 0, size, null, metadata, null, null, null,
+            null, sequenceNumber, null, headers, accessConditions.leaseAccessConditions(), null,
             accessConditions.modifiedAccessConditions(), Context.NONE))
             .map(rb -> new SimpleResponse<>(rb, new PageBlobItem(rb.deserializedHeaders())));
     }
@@ -189,9 +189,9 @@ public final class PageBlobAsyncClient extends BlobAsyncClient {
         String pageRangeStr = pageRangeToString(pageRange);
 
         return postProcessResponse(this.azureBlobStorage.pageBlobs().uploadPagesWithRestResponseAsync(null,
-            null, body, pageRange.end() - pageRange.start() + 1, null,
+            null, body, pageRange.end() - pageRange.start() + 1, null, null,
             null, pageRangeStr, null, null, null, null,
-            pageBlobAccessConditions.leaseAccessConditions(), pageBlobAccessConditions.sequenceNumberAccessConditions(),
+            pageBlobAccessConditions.leaseAccessConditions(), null, pageBlobAccessConditions.sequenceNumberAccessConditions(),
             pageBlobAccessConditions.modifiedAccessConditions(), Context.NONE))
             .map(rb -> new SimpleResponse<>(rb, new PageBlobItem(rb.deserializedHeaders())));
     }
@@ -272,7 +272,7 @@ public final class PageBlobAsyncClient extends BlobAsyncClient {
         destAccessConditions = destAccessConditions == null ? new PageBlobAccessConditions() : destAccessConditions;
 
         return postProcessResponse(this.azureBlobStorage.pageBlobs().uploadPagesFromURLWithRestResponseAsync(
-            null, null, sourceURL, sourceRangeString, 0, rangeString, sourceContentMD5,
+            null, null, sourceURL, sourceRangeString, 0, rangeString, sourceContentMD5, null,
             null, null, destAccessConditions.leaseAccessConditions(),
             destAccessConditions.sequenceNumberAccessConditions(), destAccessConditions.modifiedAccessConditions(),
             sourceAccessConditions, Context.NONE))

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/AppendBlobsImpl.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/AppendBlobsImpl.java
@@ -32,11 +32,12 @@ import com.azure.storage.blob.models.ModifiedAccessConditions;
 import com.azure.storage.blob.models.SourceModifiedAccessConditions;
 import com.azure.storage.blob.models.StorageErrorException;
 import io.netty.buffer.ByteBuf;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
 import java.net.URL;
 import java.time.OffsetDateTime;
 import java.util.Map;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 /**
  * An instance of this class provides access to all the operations defined in
@@ -78,7 +79,7 @@ public final class AppendBlobsImpl {
         @Put("{containerName}/{blob}")
         @ExpectedResponses({201})
         @UnexpectedResponseExceptionType(StorageErrorException.class)
-        Mono<AppendBlobsAppendBlockResponse> appendBlock(@PathParam("containerName") String containerName, @PathParam("blob") String blob, @HostParam("url") String url, @BodyParam("application/xml; charset=utf-8") Flux<ByteBuf> body, @QueryParam("timeout") Integer timeout, @HeaderParam("Content-Length") long contentLength, @HeaderParam("Content-MD5") String transactionalContentMD5, @HeaderParam("x-ms-content-crc64") String transactionalContentCrc64, @QueryParam("x-ms-encryption-key") String xMsEncryptionKey, @QueryParam("x-ms-encryption-key-sha256") String xMsEncryptionKeySha256, @QueryParam("x-ms-encryption-algorithm") EncryptionAlgorithmType xMsEncryptionAlgorithm, @HeaderParam("x-ms-version") String version, @HeaderParam("x-ms-client-request-id") String requestId, @QueryParam("comp") String comp, @HeaderParam("x-ms-lease-id") String leaseId, @HeaderParam("x-ms-blob-condition-maxsize") Long maxSize, @HeaderParam("x-ms-blob-condition-appendpos") Long appendPosition, @QueryParam("x-ms-encryption-scope") String encryptionScope, @HeaderParam("If-Modified-Since") DateTimeRfc1123 ifModifiedSince, @HeaderParam("If-Unmodified-Since") DateTimeRfc1123 ifUnmodifiedSince, @HeaderParam("If-Match") String ifMatch, @HeaderParam("If-None-Match") String ifNoneMatch, Context context);
+        Mono<AppendBlobsAppendBlockResponse> appendBlock(@PathParam("containerName") String containerName, @PathParam("blob") String blob, @HostParam("url") String url, @BodyParam("application/octet-stream") Flux<ByteBuf> body, @QueryParam("timeout") Integer timeout, @HeaderParam("Content-Length") long contentLength, @HeaderParam("Content-MD5") String transactionalContentMD5, @HeaderParam("x-ms-content-crc64") String transactionalContentCrc64, @QueryParam("x-ms-encryption-key") String xMsEncryptionKey, @QueryParam("x-ms-encryption-key-sha256") String xMsEncryptionKeySha256, @QueryParam("x-ms-encryption-algorithm") EncryptionAlgorithmType xMsEncryptionAlgorithm, @HeaderParam("x-ms-version") String version, @HeaderParam("x-ms-client-request-id") String requestId, @QueryParam("comp") String comp, @HeaderParam("x-ms-lease-id") String leaseId, @HeaderParam("x-ms-blob-condition-maxsize") Long maxSize, @HeaderParam("x-ms-blob-condition-appendpos") Long appendPosition, @QueryParam("x-ms-encryption-scope") String encryptionScope, @HeaderParam("If-Modified-Since") DateTimeRfc1123 ifModifiedSince, @HeaderParam("If-Unmodified-Since") DateTimeRfc1123 ifUnmodifiedSince, @HeaderParam("If-Match") String ifMatch, @HeaderParam("If-None-Match") String ifNoneMatch, Context context);
 
         @Put("{containerName}/{blob}")
         @ExpectedResponses({201})

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/models/BlobHierarchyListSegment.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/models/BlobHierarchyListSegment.java
@@ -6,7 +6,9 @@ package com.azure.storage.blob.models;
 
 import com.azure.core.implementation.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,6 +16,7 @@ import java.util.List;
  * The BlobHierarchyListSegment model.
  */
 @JacksonXmlRootElement(localName = "Blobs")
+@JsonDeserialize(using = CustomHierarchicalListingDeserializer.class)
 @Fluent
 public final class BlobHierarchyListSegment {
     /*

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/models/BlobItem.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/models/BlobItem.java
@@ -7,6 +7,7 @@ package com.azure.storage.blob.models;
 import com.azure.core.implementation.annotation.Fluent;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import java.util.Map;
 
 /**
  * An Azure Storage blob.
@@ -48,13 +49,19 @@ public final class BlobItem {
      * The metadata property.
      */
     @JsonProperty(value = "Metadata")
-    private BlobMetadata metadata;
+    private Map<String, String> metadata;
 
     /*
      * The tags property.
      */
     @JsonProperty(value = "Tags")
     private BlobTags tags;
+
+    /*
+     * The isPrefix property.
+     */
+    @JsonProperty(value = "IsPrefix")
+    private Boolean isPrefix;
 
     /**
      * Get the name property: The name property.
@@ -161,7 +168,7 @@ public final class BlobItem {
      *
      * @return the metadata value.
      */
-    public BlobMetadata metadata() {
+    public Map<String, String> metadata() {
         return this.metadata;
     }
 
@@ -171,7 +178,7 @@ public final class BlobItem {
      * @param metadata the metadata value to set.
      * @return the BlobItem object itself.
      */
-    public BlobItem metadata(BlobMetadata metadata) {
+    public BlobItem metadata(Map<String, String> metadata) {
         this.metadata = metadata;
         return this;
     }
@@ -193,6 +200,26 @@ public final class BlobItem {
      */
     public BlobItem tags(BlobTags tags) {
         this.tags = tags;
+        return this;
+    }
+
+    /**
+     * Get the isPrefix property: The isPrefix property.
+     *
+     * @return the isPrefix value.
+     */
+    public Boolean isPrefix() {
+        return this.isPrefix;
+    }
+
+    /**
+     * Set the isPrefix property: The isPrefix property.
+     *
+     * @param isPrefix the isPrefix value to set.
+     * @return the BlobItem object itself.
+     */
+    public BlobItem isPrefix(Boolean isPrefix) {
+        this.isPrefix = isPrefix;
         return this;
     }
 }

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/AppendBlobAPITest.groovy
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/AppendBlobAPITest.groovy
@@ -157,7 +157,7 @@ class AppendBlobAPITest extends APISpec {
 
         downloadStream.toByteArray() == defaultData.array()
         validateBasicHeaders(appendResponse.headers())
-        appendResponse.value().contentMD5() != null
+        appendResponse.headers().value("x-ms-content-crc64") != null
         appendResponse.value().blobAppendOffset() != null
         appendResponse.value().blobCommittedBlockCount() != null
         Integer.parseInt(bu.getProperties().headers().value("x-ms-blob-committed-block-count")) == 1

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/BlockBlobAPITest.groovy
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/BlockBlobAPITest.groovy
@@ -32,7 +32,7 @@ class BlockBlobAPITest extends APISpec {
 
         expect:
         response.statusCode() == 201
-        headers.value("Content-MD5") != null
+        headers.value("x-ms-content-crc64") != null
         headers.value("x-ms-request-id") != null
         headers.value("x-ms-version") != null
         headers.value("Date") != null
@@ -128,7 +128,7 @@ class BlockBlobAPITest extends APISpec {
         then:
         headers.value("x-ms-request-id") != null
         headers.value("x-ms-version") != null
-        headers.value("Content-MD5") != null
+        headers.value("x-ms-content-crc64") != null
         headers.value("x-ms-request-server-encrypted") != null
 
 
@@ -311,7 +311,7 @@ class BlockBlobAPITest extends APISpec {
         then:
         response.statusCode() == 201
         validateBasicHeaders(headers)
-        headers.value("Content-MD5")
+        headers.value("x-ms-content-crc64")
         Boolean.parseBoolean(headers.value("x-ms-request-server-encrypted"))
     }
 

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/PageBlobAPITest.groovy
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/PageBlobAPITest.groovy
@@ -167,7 +167,7 @@ class PageBlobAPITest extends APISpec {
         then:
         response.statusCode() == 201
         validateBasicHeaders(response.headers())
-        response.value().contentMD5() != null
+        response.headers().value("x-ms-content-crc64") != null
         response.value().blobSequenceNumber() == 0
         response.value().isServerEncrypted()
     }

--- a/sdk/storage/azure-storage-blob/swagger/README.md
+++ b/sdk/storage/azure-storage-blob/swagger/README.md
@@ -22,6 +22,8 @@ cd <swagger-folder>
 autorest --use=C:/work/autorest.java --use=C:/work/autorest.modeler --version=2.0.4280
 ```
 
+Due to limitations, after generation has completed add the `@JsonDeserialize(using = CustomHierarchicalListingDeserializer.class)` annotation to `BlobHierarchyListSegment`.
+
 ### Code generation settings
 ``` yaml
 input-file: ./blob-2019-02-02.json

--- a/sdk/storage/azure-storage-blob/swagger/README.md
+++ b/sdk/storage/azure-storage-blob/swagger/README.md
@@ -229,6 +229,15 @@ directive:
     }
 ```
 
+### /{containerName}/{blob}?comp=appendblock
+``` yaml
+directive:
+- from: swagger-document
+  where: $["x-ms-paths"]["/{containerName}/{blob}?comp=appendblock"]
+  transform: >
+    $.put.consumes = ["application/octet-stream"];
+```
+
 ### /{containerName}/{blob}?BlockBlob
 ``` yaml
 directive:

--- a/sdk/storage/azure-storage-blob/swagger/README.md
+++ b/sdk/storage/azure-storage-blob/swagger/README.md
@@ -661,8 +661,18 @@ directive:
       $.properties.Metadata.additionalProperties = { "type": "string" };
       delete $.properties.Metadata.$ref;
       $.properties.VersionId = { "type": "string" };
-      $.properties.IsPrefix = { "type": "boolean" };
     }
+    $.properties.IsPrefix = { "type": "boolean" };
+```
+
+### BlobMetadata
+Deleting out Encryption until https://github.com/Azure/azure-sdk-for-java/issues/5000 is determined.
+``` yaml
+directive:
+- from: swagger-document
+  where: $.definitions.BlobMetadata
+  transform: >
+    delete $.properties
 ```
 
 ### BlobProperties


### PR DESCRIPTION
Updated Azure Storage to use the 2019-02-02 protocol layer and fixed Swagger via transforms. Additionally, updated some unit test based on service changes and added SpotBugs exclusions to autogen code.